### PR TITLE
Bugs/6 problem with inline themes on first render

### DIFF
--- a/Blazorade.Mermaid/wwwroot/js/blazoradeMermaid.js
+++ b/Blazorade.Mermaid/wwwroot/js/blazoradeMermaid.js
@@ -2,18 +2,44 @@
 import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
 
 export function run(id, definition) {
-
+    //console.log(`Rendering diagram on element with ID '${id}'`, definition);
     var elem = document.getElementById(id);
     elem.removeAttribute("data-processed");
 
     elem.innerHTML = definition;
-    mermaid.run({ querySelector: "#" + id });
+    renderOnly("#" + id);
 }
 
+var renderCount = 0;
 export function renderOnly(selector) {
+    //console.log("Rendering diagrams on elements with selector", selector, renderCount);
+
+    if (renderCount == 0) {
+        renderCount = 1;
+        prerenderDiagram();
+    }
+
     mermaid.run({ querySelector: selector });
+    renderCount++;
 }
 
-function isEmpty(value) {
-    return (value == null || (typeof value === "string" && value.trim().length === 0));
+/**
+ * This function is called if no diagrams have been rendered previously. It is used to render a very simple
+ * flow chart diagram with no themes. Once the diagram has been rendered, it is removed from the DOM.
+ * This is to work around a problem that occurs on initial rendering of diagrams that include inline 
+ * themes. That problem does not occur after the initial diagram has been rendered.
+ */
+function prerenderDiagram() {
+    var body = document.getElementsByTagName("body");
+    if (body.length > 0) {
+        var diagElement = document.createElement("pre");
+        var dt = new Date();
+        var id = "blzrd-" + dt.getFullYear() + dt.getMonth() + dt.getDate() + dt.getHours() + dt.getMinutes() + dt.getSeconds() + dt.getMilliseconds();
+        diagElement.setAttribute("id", id);
+        body.item(0).appendChild(diagElement);
+
+        run(id, "flowchart TB\n    a-->b");
+
+        body.item(0).removeChild(diagElement);
+    }
 }

--- a/MermaidSampleLib/MultiDiagrams.razor
+++ b/MermaidSampleLib/MultiDiagrams.razor
@@ -28,6 +28,17 @@ flowchart TB
 ";
     string Def2 = @"
 sequenceDiagram
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#33c481',
+      'primaryTextColor': '#242424',
+      'secondaryColor': '#fff',
+      'fontSize': '16px'
+    }
+  }
+}%%
     autonumber
     Alice->>John: Hello John, how are you?
     loop Healthcheck

--- a/MermaidSampleLib/RenderOnlyDiagrams.razor
+++ b/MermaidSampleLib/RenderOnlyDiagrams.razor
@@ -9,6 +9,17 @@
 
 <h4>Flowchart</h4>
 <pre class=""mermaid"">
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#33c481',
+      'primaryTextColor': '#242424',
+      'secondaryColor': '#fff',
+      'fontSize': '16px'
+    }
+  }
+}%%
 flowchart TB
     c1-->a2
     subgraph one

--- a/MermaidSampleLib/SampleDiagramsProvider.razor
+++ b/MermaidSampleLib/SampleDiagramsProvider.razor
@@ -24,6 +24,17 @@
     }
 
     const string dg0 = @"
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#33c481',
+      'primaryTextColor': '#242424',
+      'secondaryColor': '#fff',
+      'fontSize': '16px'
+    }
+  }
+}%%
 flowchart TB
     c1-->a2
     subgraph one

--- a/MermaidServerApp/Pages/SingleRenderOnly.razor
+++ b/MermaidServerApp/Pages/SingleRenderOnly.razor
@@ -1,0 +1,33 @@
+﻿@page "/single-render-only"
+
+<h1>Single Render-Only Diagram</h1>
+
+<pre class="mermaid">
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#33c481',
+      'primaryTextColor': '#242424',
+      'secondaryColor': '#fff',
+      'fontSize': '16px'
+    }
+  }
+}%%
+flowchart TB
+    c1-->a2
+    subgraph one
+    a1-->a2
+    end
+    subgraph two
+    b1-->b2
+    end
+    subgraph three
+    c1-->c2
+    end
+    one --> two
+    three --> two
+    two --> c2
+</pre>
+
+<MermaidRender Selector=".mermaid" />

--- a/MermaidServerApp/Shared/Menu.razor
+++ b/MermaidServerApp/Shared/Menu.razor
@@ -3,3 +3,4 @@
 | [<a href="/edit">Edit Diagram</a>]
 | [<a href="/multi">Multiple Diagrams</a>]
 | [<a href="/render-only">Render Only</a>]
+| [<a href="/single-render-only">Single Render Only</a>]


### PR DESCRIPTION
Fixed the first-render bug for diagrams with inline themes.

The JavaScript component in Blazorade Mermaid now keeps a count of how many diagrams it has rendered. If that count is 0, a very simple flowchart diagram with no inline themes is added to the DOM and rendered. Once the diagram is rendered, it is removed from the DOM.

This is enough for Mermaid to render properly, also diagrams with inline themes.