### PR TITLE
Adds a property used to set the Mermaid component security level

### DIFF
--- a/Blazorade.Mermaid/Blazorade.Mermaid.xml
+++ b/Blazorade.Mermaid/Blazorade.Mermaid.xml
@@ -4,28 +4,14 @@
         <name>Blazorade.Mermaid</name>
     </assembly>
     <members>
-        <member name="T:Blazorade.Mermaid.Components.MermaidConfiguration">
-            <summary>
-            Represents configuration properties of the Mermaid component.
-            </summary>
-        </member>
-        <member name="P:Blazorade.Mermaid.Components.MermaidConfiguration.SecurityLevel">
-            <summary>
-            The security level to use for the diagram.
-            </summary>
-            <remarks>
-            The default value is <c>strict</c>.
-            See https://mermaid.js.org/config/schema-docs/config.html#securitylevel for more information.
-            </remarks>
-        </member>
         <member name="T:Blazorade.Mermaid.Components.MermaidComponentBase">
             <summary>
             A base class for components with Mermaid functionality.
             </summary>
         </member>
-        <member name="P:Blazorade.Mermaid.Components.MermaidComponentBase.Configuration">
+        <member name="P:Blazorade.Mermaid.Components.MermaidComponentBase.SecurityLevel">
             <summary>
-            The (optional) configuration for this Mermaid component.
+            Level of trust for parsed diagram.
             </summary>
         </member>
         <member name="P:Blazorade.Mermaid.Components.MermaidComponentBase.JSRuntime">
@@ -36,6 +22,11 @@
         <member name="M:Blazorade.Mermaid.Components.MermaidComponentBase.GetBlazoradeMermaidModuleAsync">
             <summary>
             Returns a reference to the Blazorade Mermaid JavaScript file.
+            </summary>
+        </member>
+        <member name="M:Blazorade.Mermaid.Components.MermaidComponentBase.GetConfig">
+            <summary>
+            Returns a configuration object to send to Mermaid when rendering diagrams.
             </summary>
         </member>
         <member name="T:Blazorade.Mermaid.Components.MermaidDiagram">
@@ -103,6 +94,33 @@
         <member name="P:Blazorade.Mermaid.Model.ElementClickCallbackArgs.Id">
             <summary>
             The Mermaid ID of the element that was clicked.
+            </summary>
+        </member>
+        <member name="T:Blazorade.Mermaid.SecurityLevel">
+            <summary>
+            Defines different security levels for Mermaid diagrams.
+            </summary>
+        </member>
+        <member name="F:Blazorade.Mermaid.SecurityLevel.Strict">
+            <summary>
+            Default. HTML tags in the text are encoded and click functionality is disabled.
+            </summary>
+        </member>
+        <member name="F:Blazorade.Mermaid.SecurityLevel.Loose">
+            <summary>
+            HTML tags in text are allowed and click functionality is enabled.
+            </summary>
+        </member>
+        <member name="F:Blazorade.Mermaid.SecurityLevel.AntiScript">
+            <summary>
+            HTML tags in text are allowed (only script elements are removed), and click functionality is enabled.
+            </summary>
+        </member>
+        <member name="F:Blazorade.Mermaid.SecurityLevel.Sandbox">
+            <summary>
+            With this security level, all rendering takes place in a sandboxed iframe. This prevent any JavaScript
+            from running in the context. This may hinder interactive functionality of the diagram, like scripts,
+            popups in the sequence diagram, or links to other tabs or targets, etc.
             </summary>
         </member>
     </members>

--- a/Blazorade.Mermaid/Blazorade.Mermaid.xml
+++ b/Blazorade.Mermaid/Blazorade.Mermaid.xml
@@ -4,9 +4,28 @@
         <name>Blazorade.Mermaid</name>
     </assembly>
     <members>
+        <member name="T:Blazorade.Mermaid.Components.MermaidConfiguration">
+            <summary>
+            Represents configuration properties of the Mermaid component.
+            </summary>
+        </member>
+        <member name="P:Blazorade.Mermaid.Components.MermaidConfiguration.SecurityLevel">
+            <summary>
+            The security level to use for the diagram.
+            </summary>
+            <remarks>
+            The default value is <c>strict</c>.
+            See https://mermaid.js.org/config/schema-docs/config.html#securitylevel for more information.
+            </remarks>
+        </member>
         <member name="T:Blazorade.Mermaid.Components.MermaidComponentBase">
             <summary>
             A base class for components with Mermaid functionality.
+            </summary>
+        </member>
+        <member name="P:Blazorade.Mermaid.Components.MermaidComponentBase.Configuration">
+            <summary>
+            The (optional) configuration for this Mermaid component.
             </summary>
         </member>
         <member name="P:Blazorade.Mermaid.Components.MermaidComponentBase.JSRuntime">

--- a/Blazorade.Mermaid/Components/MermaidComponentBase.cs
+++ b/Blazorade.Mermaid/Components/MermaidComponentBase.cs
@@ -10,8 +10,18 @@ using System.Threading.Tasks;
 
 namespace Blazorade.Mermaid.Components
 {
+    /// <summary>
+    /// Represents configuration properties of the Mermaid component.
+    /// </summary>
     public sealed record MermaidConfiguration
     {
+        /// <summary>
+        /// The security level to use for the diagram.
+        /// </summary>
+        /// <remarks>
+        /// The default value is <c>strict</c>.
+        /// See https://mermaid.js.org/config/schema-docs/config.html#securitylevel for more information.
+        /// </remarks>
         [JsonPropertyName("securityLevel")]
         public string? SecurityLevel { get; init; }
     }
@@ -22,6 +32,9 @@ namespace Blazorade.Mermaid.Components
     public abstract class MermaidComponentBase : BlazoradeComponentBase
     {
 
+        /// <summary>
+        /// The (optional) configuration for this Mermaid component.
+        /// </summary>
         [Parameter]
         public MermaidConfiguration? Configuration { get; set; }
 

--- a/Blazorade.Mermaid/Components/MermaidComponentBase.cs
+++ b/Blazorade.Mermaid/Components/MermaidComponentBase.cs
@@ -10,21 +10,6 @@ using System.Threading.Tasks;
 
 namespace Blazorade.Mermaid.Components
 {
-    /// <summary>
-    /// Represents configuration properties of the Mermaid component.
-    /// </summary>
-    public sealed record MermaidConfiguration
-    {
-        /// <summary>
-        /// The security level to use for the diagram.
-        /// </summary>
-        /// <remarks>
-        /// The default value is <c>strict</c>.
-        /// See https://mermaid.js.org/config/schema-docs/config.html#securitylevel for more information.
-        /// </remarks>
-        [JsonPropertyName("securityLevel")]
-        public string? SecurityLevel { get; init; }
-    }
 
     /// <summary>
     /// A base class for components with Mermaid functionality.
@@ -33,11 +18,12 @@ namespace Blazorade.Mermaid.Components
     {
 
         /// <summary>
-        /// The (optional) configuration for this Mermaid component.
+        /// Level of trust for parsed diagram.
         /// </summary>
         [Parameter]
-        public MermaidConfiguration? Configuration { get; set; }
+        public SecurityLevel? SecurityLevel { get; set; }
 
+        
         /// <summary>
         /// Injected JavaScript Runtime implementation.
         /// </summary>
@@ -51,6 +37,21 @@ namespace Blazorade.Mermaid.Components
         protected async ValueTask<IJSObjectReference> GetBlazoradeMermaidModuleAsync()
         {
             return _BlazoradeMermaidModule ??= await this.JSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Blazorade.Mermaid/js/blazoradeMermaid.js");
+        }
+
+        /// <summary>
+        /// Returns a configuration object to send to Mermaid when rendering diagrams.
+        /// </summary>
+        protected Dictionary<string, object?> GetConfig()
+        {
+            var config = new Dictionary<string, object?>();
+
+            if(this.SecurityLevel.HasValue)
+            {
+                config["securityLevel"] = this.SecurityLevel?.ToString()?.ToLower();
+            }
+
+            return config;
         }
     }
 }

--- a/Blazorade.Mermaid/Components/MermaidComponentBase.cs
+++ b/Blazorade.Mermaid/Components/MermaidComponentBase.cs
@@ -5,15 +5,25 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Blazorade.Mermaid.Components
 {
+    public sealed record MermaidConfiguration
+    {
+        [JsonPropertyName("securityLevel")]
+        public string? SecurityLevel { get; init; }
+    }
+
     /// <summary>
     /// A base class for components with Mermaid functionality.
     /// </summary>
     public abstract class MermaidComponentBase : BlazoradeComponentBase
     {
+
+        [Parameter]
+        public MermaidConfiguration? Configuration { get; set; }
 
         /// <summary>
         /// Injected JavaScript Runtime implementation.

--- a/Blazorade.Mermaid/Components/MermaidDiagram.razor.cs
+++ b/Blazorade.Mermaid/Components/MermaidDiagram.razor.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Data;
 using System.Linq;
 using System.Text;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Blazorade.Mermaid.Components

--- a/Blazorade.Mermaid/Components/MermaidDiagram.razor.cs
+++ b/Blazorade.Mermaid/Components/MermaidDiagram.razor.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Blazorade.Mermaid.Components
@@ -98,10 +99,9 @@ click s1 ""https://github.com/Blazorade/Blazorade-Mermaid/wiki"" ""Open Blazorad
         private async ValueTask UpdateDiagramAsync()
         {
             var jsModule = await this.GetBlazoradeMermaidModuleAsync();
-            await jsModule.InvokeVoidAsync("run", this.Id, this.Definition);
+            await jsModule.InvokeVoidAsync("run", this.Id, this.Definition, this.Configuration);
 
             await this.RegisterClickCallbacksAsync();
         }
-
     }
 }

--- a/Blazorade.Mermaid/Components/MermaidDiagram.razor.cs
+++ b/Blazorade.Mermaid/Components/MermaidDiagram.razor.cs
@@ -98,7 +98,7 @@ click s1 ""https://github.com/Blazorade/Blazorade-Mermaid/wiki"" ""Open Blazorad
         private async ValueTask UpdateDiagramAsync()
         {
             var jsModule = await this.GetBlazoradeMermaidModuleAsync();
-            await jsModule.InvokeVoidAsync("run", this.Id, this.Definition, this.Configuration);
+            await jsModule.InvokeVoidAsync("run", this.Id, this.Definition, this.GetConfig());
 
             await this.RegisterClickCallbacksAsync();
         }

--- a/Blazorade.Mermaid/Components/MermaidRender.razor.cs
+++ b/Blazorade.Mermaid/Components/MermaidRender.razor.cs
@@ -32,7 +32,7 @@ namespace Blazorade.Mermaid.Components
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             var jsModule = await this.GetBlazoradeMermaidModuleAsync();
-            await jsModule.InvokeVoidAsync("renderOnly", this.Selector);
+            await jsModule.InvokeVoidAsync("renderOnly", this.Selector, this.Configuration);
         }
     }
 }

--- a/Blazorade.Mermaid/Components/MermaidRender.razor.cs
+++ b/Blazorade.Mermaid/Components/MermaidRender.razor.cs
@@ -32,7 +32,7 @@ namespace Blazorade.Mermaid.Components
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             var jsModule = await this.GetBlazoradeMermaidModuleAsync();
-            await jsModule.InvokeVoidAsync("renderOnly", this.Selector, this.Configuration);
+            await jsModule.InvokeVoidAsync("renderOnly", this.Selector, this.GetConfig());
         }
     }
 }

--- a/Blazorade.Mermaid/SecurityLevel.cs
+++ b/Blazorade.Mermaid/SecurityLevel.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazorade.Mermaid
+{
+    /// <summary>
+    /// Defines different security levels for Mermaid diagrams.
+    /// </summary>
+    public enum SecurityLevel
+    {
+        /// <summary>
+        /// Default. HTML tags in the text are encoded and click functionality is disabled.
+        /// </summary>
+        Strict,
+        /// <summary>
+        /// HTML tags in text are allowed and click functionality is enabled.
+        /// </summary>
+        Loose,
+        /// <summary>
+        /// HTML tags in text are allowed (only script elements are removed), and click functionality is enabled.
+        /// </summary>
+        AntiScript,
+        /// <summary>
+        /// With this security level, all rendering takes place in a sandboxed iframe. This prevent any JavaScript
+        /// from running in the context. This may hinder interactive functionality of the diagram, like scripts,
+        /// popups in the sequence diagram, or links to other tabs or targets, etc.
+        /// </summary>
+        Sandbox
+    }
+}

--- a/Blazorade.Mermaid/wwwroot/js/blazoradeMermaid.js
+++ b/Blazorade.Mermaid/wwwroot/js/blazoradeMermaid.js
@@ -1,22 +1,26 @@
 ﻿
 import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
 
-export function run(id, definition) {
+export function run(id, definition, configuration) {
     //console.log(`Rendering diagram on element with ID '${id}'`, definition);
     var elem = document.getElementById(id);
     elem.removeAttribute("data-processed");
 
     elem.innerHTML = definition;
-    renderOnly("#" + id);
+    renderOnly("#" + id, configuration);
 }
 
 var renderCount = 0;
-export function renderOnly(selector) {
+export function renderOnly(selector, configuration) {
     //console.log("Rendering diagrams on elements with selector", selector, renderCount);
 
     if (renderCount == 0) {
         renderCount = 1;
         prerenderDiagram();
+    }
+
+    if (configuration) {
+        mermaid.initialize(configuration);
     }
 
     mermaid.run({ querySelector: selector });

--- a/Blazorade.Mermaid/wwwroot/js/blazoradeMermaid.js
+++ b/Blazorade.Mermaid/wwwroot/js/blazoradeMermaid.js
@@ -2,7 +2,7 @@
 import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
 
 export function run(id, definition, configuration) {
-    //console.log(`Rendering diagram on element with ID '${id}'`, definition);
+    console.debug("run (id, definition, configuration)", id, definition, configuration);
     var elem = document.getElementById(id);
     elem.removeAttribute("data-processed");
 
@@ -12,7 +12,7 @@ export function run(id, definition, configuration) {
 
 var renderCount = 0;
 export function renderOnly(selector, configuration) {
-    //console.log("Rendering diagrams on elements with selector", selector, renderCount);
+    console.debug("renderOnly(selector, configuration)", selector, configuration);
 
     if (renderCount == 0) {
         renderCount = 1;

--- a/MermaidSampleLib/MultiDiagrams.razor
+++ b/MermaidSampleLib/MultiDiagrams.razor
@@ -3,9 +3,8 @@
 <h4>Flowchart</h4>
 <MermaidDiagram Definition="@this.Def1" />
 
-<h4>Sequence Diagram</h4>
-<MermaidDiagram Configuration="@(new MermaidConfiguration { SecurityLevel = "loose" })"
-                Definition="@this.Def2" />
+<h4>Sequence Diagram (Security Level: Loose)</h4>
+<MermaidDiagram SecurityLevel="SecurityLevel.Loose" Definition="@this.Def2" />
 
 <h4>Default Diagram</h4>
 <MermaidDiagram></MermaidDiagram>

--- a/MermaidSampleLib/MultiDiagrams.razor
+++ b/MermaidSampleLib/MultiDiagrams.razor
@@ -4,7 +4,8 @@
 <MermaidDiagram Definition="@this.Def1" />
 
 <h4>Sequence Diagram</h4>
-<MermaidDiagram Definition="@this.Def2" />
+<MermaidDiagram Configuration="@(new MermaidConfiguration { SecurityLevel = "loose" })"
+                Definition="@this.Def2" />
 
 <h4>Default Diagram</h4>
 <MermaidDiagram></MermaidDiagram>
@@ -40,6 +41,8 @@ sequenceDiagram
   }
 }%%
     autonumber
+    participant Alice
+    link Alice: Mermaid @ https://mermaid.js.org/
     Alice->>John: Hello John, how are you?
     loop Healthcheck
         John->>John: Fight against hypochondria

--- a/MermaidSampleLib/RenderOnlyDiagrams.razor
+++ b/MermaidSampleLib/RenderOnlyDiagrams.razor
@@ -1,6 +1,6 @@
 ﻿@this.HtmlContent
 
-<MermaidRender Selector="pre.mermaid" />
+<MermaidRender Selector="pre.mermaid" SecurityLevel="SecurityLevel.Loose" />
 
 @code {
 
@@ -40,7 +40,7 @@ flowchart TB
 <pre class=""mermaid"">
 sequenceDiagram
     autonumber
-    Alice->>John: Hello John, how are you?
+    Alice->>John: <b>Hello John</b>, how are you?
     loop Healthcheck
         John->>John: Fight against hypochondria
     end


### PR DESCRIPTION
Exposes a `MermaidConfiguration? Configuration { get; set; }` property on `MermaidComponentBase` which allows users to initialize they underlying Mermaid library. In particular, it allows the user to change the `SecurityLevel` property (`securityLevel` on the underlying library) from the default `strict`, which allows use of interactive Mermaid features such as sequence diagram participant menus.

The `MermaidConfiguration` type could be expanded in the future to allow configuration of other library settings (but is beyond the scope of this PR).

Resolves #9 